### PR TITLE
feat/1001 ✨ : vinyl 구현, 음악이랑 정방향 맞추기

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,101 @@
       <canvas id="left-canvas"></canvas>
       <audio id="left-audio" ></audio>
     </div>
+    <div class="left-deck-vinyl">
+      <svg width="512px" viewBox="0 0 512 512" id="record_svg">
+        <g>
+          <g id="record_group">
+          <circle
+            r="256"
+            transform="scale(1,-1)"
+            cy="-256"
+            cx="256"
+            style="fill:#000000;fill-opacity:1" />
+          <path
+            d="m 343,256 a 87,87 0 0 1 -87,87 87,87 0 0 1 -87,-87 87,87 0 0 1 87,-87 87,87 0 0 1 87,87 z"
+            style="fill:#C64945;fill-opacity:1;stroke:none;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none" />
+          <circle
+            style="fill:none;fill-opacity:1;stroke:#ffcc00;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none"
+            cx="256"
+            cy="256"
+            r="72" />
+          <path
+            d="m 270,256 a 14,14 0 0 1 -14,14 14,14 0 0 1 -14,-14 14,14 0 0 1 14,-14 14,14 0 0 1 14,14 z"
+            style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none" />
+          <text
+            id="text4175"
+            y="225.5"
+            x="212.80206"
+            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+            xml:space="preserve"><tspan
+              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Futura;-inkscape-font-specification:'Futura Bold'"
+              y="225.5"
+              x="200.91144">Vinyla Shake</tspan></text>
+          <text
+            xml:space="preserve"
+            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+            x="210.76865"
+            y="290.0"><tspan
+              x="225.76865"
+              y="290.0"
+              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.5px;font-family:Futura;-inkscape-font-specification:'Futura Bold'">Vinyla JS</tspan></text>
+          <text
+            y="305.0"
+            x="208.4707"
+            style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:10px;line-height:125%;font-family:Futura;-inkscape-font-specification:'Futura Medium';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+            xml:space="preserve"><tspan
+              y="305.0"
+              x="208.4707">ECMAScript Records</tspan></text>
+          </g>
+          <g>
+            <path
+              style="fill:none;fill-opacity:1;stroke:#cccccc;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none"
+              d="m 60,256 c 6e-6,-108.24781 87.75219,-195.99999 196,-195.99999" />
+            <path
+              style="fill:none;fill-opacity:1;stroke:#cccccc;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none"
+              d="m 100,256 c 0,-86.15642 69.84358,-156 156,-156" />
+            <path
+              style="fill:none;fill-opacity:1;stroke:#cccccc;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none"
+              d="m 128,256 c 0,-70.69245 57.30755,-128 128,-128" />
+          </g>
+          <g
+            style="stroke:#666666"
+            transform="matrix(-1,0,0,-1,512,1052.36222)">
+            <path
+              d="m 60,796.36217 c 6e-6,-108.24781 87.75219,-195.99999 196,-195.99999"
+              style="fill:none;fill-opacity:1;stroke:#666666;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none" />
+            <path
+              d="m 100,796.36218 c 0,-86.15642 69.84358,-156 156,-156"
+              style="fill:none;fill-opacity:1;stroke:#666666;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none" />
+            <path
+              d="m 128,796.36218 c 0,-70.69245 57.30755,-128 128,-128"
+              style="fill:none;fill-opacity:1;stroke:#666666;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none" />
+          </g>
+          <g id="surface_group">
+              <path
+                style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+                d="m 225,92 17,53" />
+              <path
+                style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+                d="m 442,288 18,4" />
+              <path
+                style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+                d="m 112,238 -62,-8" />
+            <g transform="matrix(1,0,0,-1,0,1052.36224)">
+              <path
+                d="m 282,912.36216 5,18"
+                style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+              <path
+                d="m 352,958.36216 8,13"
+                style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+              <path
+                d="m 112,778.36216 -62,-8"
+                style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+            </g>
+          </g>
+        </g>
+      </svg>
+    </div>
   </section>
   <section class="right-deck">
     <div class="right-deck-sound">
@@ -20,6 +115,101 @@
       <input type="file" id="right-music-input" accept=".mp3" />
       <canvas id="right-canvas"></canvas>
       <audio id="right-audio" ></audio>
+    </div>
+    <div class="right-deck-vinyl">
+      <svg width="512px" viewBox="0 0 512 512" id="record_svg">
+        <g>
+          <g id="record_group">
+          <circle
+            r="256"
+            transform="scale(1,-1)"
+            cy="-256"
+            cx="256"
+            style="fill:#000000;fill-opacity:1" />
+          <path
+            d="m 343,256 a 87,87 0 0 1 -87,87 87,87 0 0 1 -87,-87 87,87 0 0 1 87,-87 87,87 0 0 1 87,87 z"
+            style="fill:#C64945;fill-opacity:1;stroke:none;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none" />
+          <circle
+            style="fill:none;fill-opacity:1;stroke:#ffcc00;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none"
+            cx="256"
+            cy="256"
+            r="72" />
+          <path
+            d="m 270,256 a 14,14 0 0 1 -14,14 14,14 0 0 1 -14,-14 14,14 0 0 1 14,-14 14,14 0 0 1 14,14 z"
+            style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none" />
+          <text
+            id="text4175"
+            y="225.5"
+            x="212.80206"
+            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:17.5px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+            xml:space="preserve"><tspan
+              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Futura;-inkscape-font-specification:'Futura Bold'"
+              y="225.5"
+              x="200.91144">Vinyla Shake</tspan></text>
+          <text
+            xml:space="preserve"
+            style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:15px;line-height:125%;font-family:sans-serif;-inkscape-font-specification:'sans-serif Bold';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+            x="210.76865"
+            y="290.0"><tspan
+              x="225.76865"
+              y="290.0"
+              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.5px;font-family:Futura;-inkscape-font-specification:'Futura Bold'">Vinyla JS</tspan></text>
+          <text
+            y="305.0"
+            x="208.4707"
+            style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:10px;line-height:125%;font-family:Futura;-inkscape-font-specification:'Futura Medium';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+            xml:space="preserve"><tspan
+              y="305.0"
+              x="208.4707">ECMAScript Records</tspan></text>
+          </g>
+          <g>
+            <path
+              style="fill:none;fill-opacity:1;stroke:#cccccc;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none"
+              d="m 60,256 c 6e-6,-108.24781 87.75219,-195.99999 196,-195.99999" />
+            <path
+              style="fill:none;fill-opacity:1;stroke:#cccccc;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none"
+              d="m 100,256 c 0,-86.15642 69.84358,-156 156,-156" />
+            <path
+              style="fill:none;fill-opacity:1;stroke:#cccccc;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none"
+              d="m 128,256 c 0,-70.69245 57.30755,-128 128,-128" />
+          </g>
+          <g
+            style="stroke:#666666"
+            transform="matrix(-1,0,0,-1,512,1052.36222)">
+            <path
+              d="m 60,796.36217 c 6e-6,-108.24781 87.75219,-195.99999 196,-195.99999"
+              style="fill:none;fill-opacity:1;stroke:#666666;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none" />
+            <path
+              d="m 100,796.36218 c 0,-86.15642 69.84358,-156 156,-156"
+              style="fill:none;fill-opacity:1;stroke:#666666;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none" />
+            <path
+              d="m 128,796.36218 c 0,-70.69245 57.30755,-128 128,-128"
+              style="fill:none;fill-opacity:1;stroke:#666666;stroke-width:4;stroke-miterlimit:4;stroke-dasharray:none" />
+          </g>
+          <g id="surface_group">
+              <path
+                style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+                d="m 225,92 17,53" />
+              <path
+                style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+                d="m 442,288 18,4" />
+              <path
+                style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+                d="m 112,238 -62,-8" />
+            <g transform="matrix(1,0,0,-1,0,1052.36224)">
+              <path
+                d="m 282,912.36216 5,18"
+                style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+              <path
+                d="m 352,958.36216 8,13"
+                style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+              <path
+                d="m 112,778.36216 -62,-8"
+                style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+            </g>
+          </g>
+        </g>
+      </svg>
     </div>
   </section>
 </body>

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,8 +1,11 @@
 @import "./reset.css";
 @import "./soundWave.css";
+@import "./vinyl.css";
 
 body {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+
+  overflow: hidden;
 }

--- a/src/css/vinyl.css
+++ b/src/css/vinyl.css
@@ -1,0 +1,7 @@
+#record_svg {
+  display: block;
+  width: 512px;
+  margin: 20px auto;
+  cursor: pointer; cursor: hand;
+  user-select: none;
+}

--- a/src/js/vinyl.js
+++ b/src/js/vinyl.js
@@ -1,0 +1,99 @@
+let scratching = false;
+let recordGroup;
+let surfaceGroup;
+let angle = 0;
+let rotationStart = 0;
+let rotationOffset = 0;
+let lastX = 0;
+let lastY = 0;
+let size = 512;
+
+let source;
+let context;
+let lastTime;
+let lastAngle = 0;
+let duration;
+
+function onMouseDown(ev) {
+  scratching = true;
+  lastX = ev.offsetX;
+  lastY = ev.offsetY;
+
+  lastTime = context.currentTime;
+  source.playbackRate.setValueAtTime(0, lastTime);
+}
+
+function onMouseUp() {
+  scratching = false;
+  rotationOffset = angle;
+  rotationStart = -1;
+
+  source.playbackRate.setValueAtTime(1, lastTime + 0.1);
+  rotateRecord();
+}
+
+function onMouseMove(ev) {
+  if (scratching) {
+    const deltaX = ev.offsetX - lastX;
+    const deltaY = ev.offsetY - lastY;
+    let rotation = 0;
+
+    if (Math.abs(deltaX) > Math.abs(deltaY)) {
+      const direction = ev.offsetY > size / 2.0 ? -1.0 : 1.0;
+
+      rotation = (deltaX / size) * 180.0 * direction;
+    } else {
+      const direction = ev.offsetX > size / 2.0 ? 1.0 : -0.5;
+
+      rotation = (deltaY / size) * 180.0 * direction;
+    }
+
+    angle += rotation;
+    recordGroup.setAttribute("transform", "rotate(" + angle + ", 256, 256)");
+    surfaceGroup.setAttribute("transform", "rotate(" + angle + ", 256, 256)");
+
+    lastX = ev.offsetX;
+    lastY = ev.offsetY;
+
+    const diff = parseFloat((angle - lastAngle) / 3).toFixed(2);
+
+    lastAngle = angle;
+    source.playbackRate.setValueAtTime(diff, lastTime);
+  }
+}
+
+function rotateRecord(timestamp) {
+  if (!scratching && duration > context.currentTime) {
+    if (timestamp >= 0) {
+      if (rotationStart < 0) {
+        rotationStart = timestamp;
+      }
+      angle = (((timestamp - rotationStart) / 5.0) % 360.0) + rotationOffset;
+      recordGroup.setAttribute("transform", "rotate(" + angle + ", 256, 256)");
+      surfaceGroup.setAttribute("transform", "rotate(" + angle + ", 256, 256)");
+    }
+    window.requestAnimationFrame(rotateRecord);
+  }
+}
+
+export default function playVinyl(musicSource, musicContext) {
+  source = musicSource;
+  context = musicContext;
+  duration = source.buffer.duration;
+  source.start(0);
+
+  const record = document.getElementById("record_svg");
+  recordGroup = document.getElementById("record_group");
+  surfaceGroup = document.getElementById("surface_group");
+  rotateRecord();
+
+  if (window.PointerEvent) {
+    record.addEventListener("pointerdown", onMouseDown);
+    document.addEventListener("pointerup", onMouseUp);
+    document.addEventListener("pointermove", onMouseMove);
+  } else {
+    record.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("mouseup", onMouseUp);
+    document.addEventListener("mousemove", onMouseMove);
+  }
+}


### PR DESCRIPTION
* vinyl 구현
* 정방향 회전에 맞춰 (빠르거나 느리게 scratch시) 그에 맞는 playbackRate를 적용해서 자연스러운 scratch소리 구현
* scratch하지 않을 시, 음악이 끝나면 vinyl 회전 멈춤
  * 스크래치하면 그에 맞게 음악 멈추는건 아직 구현 못함.

* 특이사항
  * safari에서는 playbackRate 음수가 적용이 된다.
  * chrome에서는 적용안돼서 적용시키도록 하자.