### PR TITLE
fix/5007 🛠 : record 버튼 터치 수정, vinyl 정확도 수정, css 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Turn Table / audio Mixing / App
 
 | 처음 화면  | 음악 가져오기 | 음악실행 / 녹음 | FX 버튼조작 | 녹음 리스트
 |--|--|--|--|--|
-| <img src="/assets/기본.jpg" /> | <img src="/assets/음악가져오기.jpg"/> | <img src="/assets/녹음.jpg" /> | <img src="/assets/FX버튼.jpeg" /> | <img src="/assets/녹음리스트.jpg" /> |
+| <img src="/assets/기본.jpg" /> | <img src="/assets/음악가져오기.jpg"/> | <img src="/assets/녹음.jpg" /> | <img src="/assets/FX버튼.jpeg" /> | <img src="/assets/녹음결과.jpg" /> |
 
 # 🚬 고민들, 문제 해결과정
 

--- a/src/css/deck.css
+++ b/src/css/deck.css
@@ -3,7 +3,7 @@
 
 .deck-middle {
   display: flex;
-  justify-content: center;
+  justify-content: space-evenly;
   align-items: center;
   border-radius: 20px;
   background: linear-gradient(180deg, rgba(204, 204, 204,1) 12.12028824833703%,rgba(203, 203, 203,1) 12.12028824833703%,rgba(130, 130, 130,1) 88.94955654101994%);

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -20,5 +20,5 @@ main {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
+  height: 100vh;
 }

--- a/src/css/middle.css
+++ b/src/css/middle.css
@@ -1,5 +1,5 @@
 #record_svg {
-  width: 35vw;
+  width: 30vw;
   margin: 20px auto;
   cursor: pointer; 
   user-select: none;

--- a/src/js/Controller/recordController.js
+++ b/src/js/Controller/recordController.js
@@ -10,8 +10,14 @@ export class RecordController extends Controller {
     const recordModal = document.querySelector(".record-modal");
     const recordModalBack = document.querySelector(".record-modal-back");
 
-    recordButton.addEventListener("touchstart", this.onMouseDown.bind(this));
-    recordButton.addEventListener("touchend", this.onMouseUp.bind(this));
+    if (window.PointerEvent) {
+      recordButton.addEventListener("pointerdown", this.onMouseDown.bind(this));
+      recordButton.addEventListener("pointerup", this.onMouseUp.bind(this));
+    } else {
+      recordButton.addEventListener("mousedown", this.onMouseDown.bind(this));
+      recordButton.addEventListener("mouseup", this.onMouseUp.bind(this));
+    }
+
     recordModal.addEventListener("click", (e) => {
       e.stopPropagation();
     });

--- a/src/js/Controller/vinylController.js
+++ b/src/js/Controller/vinylController.js
@@ -98,7 +98,7 @@ export class VinylController extends Controller {
 
         rotation = (deltaX / size) * 180.0 * direction;
       } else {
-        const direction = e.offsetX > size / 2.0 ? 1.0 : -0.5;
+        const direction = e.offsetX > size / 2.0 ? 1.0 : -1.0;
 
         rotation = (deltaY / size) * 180.0 * direction;
       }

--- a/src/js/View/vinylView.js
+++ b/src/js/View/vinylView.js
@@ -8,7 +8,7 @@ export class VinylView {
 
     div.className = "deck-middle-vinyl";
     div.innerHTML = `
-    <svg width="512px" viewBox="0 0 512 512" id="record_svg">
+    <svg viewBox="0 0 512 512" id="record_svg">
           <g>
             <g id="record_group">
             <circle

--- a/src/js/deck.js
+++ b/src/js/deck.js
@@ -46,7 +46,7 @@ export class Deck {
         rotationOffset: 0,
         lastX: 0,
         lastY: 0,
-        size: 512,
+        size: document.body.clientWidth * 0.30,
         lastTime: 0,
         lastAngle: 0,
       }),


### PR DESCRIPTION
* record btn 수정
  * 앱 환경만 고려해서 Touch event만 적용해두었던 걸, pointdown, pointup으로 수정해서 마우스 이벤트도 적용 가능
* vinyl이 초기 크기에 맞게 적용되어있던 rotate 애니메이션과 이벤트를 현재 크기에 맞게 수정
* css 수정
  * 앱 환경만 고려해서, 웹에서는 아래 FX버튼이 잘 보이지 않았던걸 전체가 보이도록 수정 